### PR TITLE
Changed errpacture and logcapture method names to be cleaner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ This module contains:
 * `pkg/errcapture`
 
 ```go mdox-gen-exec="sh -c 'tail -n +6 core/pkg/errcapture/doc.go'"
-// Close a `Closer` interface safely while capturing error. It's often forgotten but it's a caller responsibility
-// to close all implementations of `Closer`, such as *os.File or io.ReaderCloser. Commonly we would use:
+// Close a `io.Closer` interface or execute any function that returns error safely while capturing error.
+// It's often forgotten but it's a caller responsibility to close all implementations of `Closer`,
+// such as *os.File or io.ReaderCloser. Commonly we would use:
 //
 // 	defer closer.Close()
 //
@@ -49,12 +50,12 @@ This module contains:
 //
 // 	func <...>(...) (err error) {
 //  	...
-//  	defer errcapture.Close(&err, closer, "log format message")
+//  	defer errcapture.Do(&err, closer.Close, "log format message")
 //
 // 		...
 // 	}
 //
-//If closer returns error, `errcapture.Close` will capture it, add to input error if not nil and return by argument.
+// If Close returns error, `errcapture.Do` will capture it, add to input error if not nil and return by argument.
 //
 // The errcapture.ExhaustClose function provide the same functionality but takes an io.ReadCloser and exhausts the whole
 // reader before closing. This is useful when trying to use http keep-alive connections because for the same connection
@@ -66,8 +67,9 @@ This module contains:
 * `pkg/logerrcapture`
 
 ```go mdox-gen-exec="sh -c 'tail -n +6 core/pkg/logerrcapture/doc.go'"
-// Close a `Closer` interface safely while logging error. It's often forgotten but it's a caller responsibility
-// to close all implementations of `Closer`, such as *os.File or io.ReaderCloser. Commonly we would use:
+// Close a `io.Closer` interface or execute any function that returns error safely while logging error.
+// It's often forgotten but it's a caller responsibility to close all implementations of `Closer`,
+// such as *os.File or io.ReaderCloser. Commonly we would use:
 //
 // 	defer closer.Close()
 //
@@ -77,12 +79,12 @@ This module contains:
 //
 // 	func <...>(...) (err error) {
 //  	...
-//  	defer logerrcapture.Close(logger, closer, "log format message")
+//  	defer logerrcapture.Do(logger, closer.Close, "log format message")
 //
 // 		...
 // 	}
 //
-// If closer returns error, `logerrcapture.Close` will capture it, add to input error if not nil and return by argument.
+// If Close returns error, `logerrcapture.Do` will capture it, add to input error if not nil and return by argument.
 //
 // The logerrcapture.ExhaustClose function provide the same functionality but takes an io.ReadCloser and exhausts the whole
 // reader before closing. This is useful when trying to use http keep-alive connections because for the same connection

--- a/core/pkg/errcapture/do.go
+++ b/core/pkg/errcapture/do.go
@@ -11,24 +11,36 @@ package errcapture
 import (
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/efficientgo/tools/core/pkg/merrors"
 	"github.com/pkg/errors"
 )
 
-type closerFunc func() error
+type doFunc func() error
 
-// Close runs function and on error return error by argument including the given error (usually
+// Do runs function and on error return error by argument including the given error (usually
 // from caller function).
-func Close(err *error, closer closerFunc, format string, a ...interface{}) {
-	*err = merrors.New(*err, errors.Wrapf(closer(), format, a...)).Err()
+func Do(err *error, doer doFunc, format string, a ...interface{}) {
+	derr := doer()
+	if err == nil {
+		return
+	}
+
+	// For os closers, it's a common case to double close. From reliability purpose this is not a problem it may only indicate
+	// surprising execution path.
+	if errors.Is(derr, os.ErrClosed) {
+		return
+	}
+
+	*err = merrors.New(*err, errors.Wrapf(derr, format, a...)).Err()
 }
 
 // ExhaustClose closes the io.ReadCloser with error capture but exhausts the reader before.
 func ExhaustClose(err *error, r io.ReadCloser, format string, a ...interface{}) {
 	_, copyErr := io.Copy(ioutil.Discard, r)
 
-	Close(err, r.Close, format, a...)
+	Do(err, r.Close, format, a...)
 
 	// Prepend the io.Copy error.
 	*err = merrors.New(copyErr, *err).Err()

--- a/core/pkg/errcapture/do_test.go
+++ b/core/pkg/errcapture/do_test.go
@@ -23,7 +23,7 @@ func (c testCloser) Close() error {
 	return c.err
 }
 
-func TestClose(t *testing.T) {
+func TestDo(t *testing.T) {
 	for _, tcase := range []struct {
 		err    error
 		closer io.Closer
@@ -53,7 +53,7 @@ func TestClose(t *testing.T) {
 	} {
 		if ok := t.Run("", func(t *testing.T) {
 			ret := tcase.err
-			Close(&ret, tcase.closer.Close, "close")
+			Do(&ret, tcase.closer.Close, "close")
 
 			if tcase.expectedErrStr == "" {
 				if ret != nil {

--- a/core/pkg/errcapture/doc.go
+++ b/core/pkg/errcapture/doc.go
@@ -3,8 +3,9 @@
 
 package errcapture
 
-// Close a `Closer` interface safely while capturing error. It's often forgotten but it's a caller responsibility
-// to close all implementations of `Closer`, such as *os.File or io.ReaderCloser. Commonly we would use:
+// Close a `io.Closer` interface or execute any function that returns error safely while capturing error.
+// It's often forgotten but it's a caller responsibility to close all implementations of `Closer`,
+// such as *os.File or io.ReaderCloser. Commonly we would use:
 //
 // 	defer closer.Close()
 //
@@ -14,12 +15,12 @@ package errcapture
 //
 // 	func <...>(...) (err error) {
 //  	...
-//  	defer errcapture.Close(&err, closer, "log format message")
+//  	defer errcapture.Do(&err, closer.Close, "log format message")
 //
 // 		...
 // 	}
 //
-//If closer returns error, `errcapture.Close` will capture it, add to input error if not nil and return by argument.
+// If Close returns error, `errcapture.Do` will capture it, add to input error if not nil and return by argument.
 //
 // The errcapture.ExhaustClose function provide the same functionality but takes an io.ReadCloser and exhausts the whole
 // reader before closing. This is useful when trying to use http keep-alive connections because for the same connection

--- a/core/pkg/logerrcapture/do_test.go
+++ b/core/pkg/logerrcapture/do_test.go
@@ -57,10 +57,10 @@ func TestCloseMoreThanOnce(t *testing.T) {
 	lc := &loggerCapturer{}
 	r := newEmulatedCloser(strings.NewReader("somestring"))
 
-	Close(lc, r.Close, "should not be called")
-	Close(lc, r.Close, "should not be called")
+	Do(lc, r.Close, "should not be called")
+	Do(lc, r.Close, "should not be called")
 	testutil.Equals(t, false, lc.WasCalled)
 
-	Close(lc, r.Close, "should be called")
+	Do(lc, r.Close, "should be called")
 	testutil.Equals(t, true, lc.WasCalled)
 }

--- a/core/pkg/logerrcapture/doc.go
+++ b/core/pkg/logerrcapture/doc.go
@@ -3,8 +3,9 @@
 
 package logerrcapture
 
-// Close a `Closer` interface safely while logging error. It's often forgotten but it's a caller responsibility
-// to close all implementations of `Closer`, such as *os.File or io.ReaderCloser. Commonly we would use:
+// Close a `io.Closer` interface or execute any function that returns error safely while logging error.
+// It's often forgotten but it's a caller responsibility to close all implementations of `Closer`,
+// such as *os.File or io.ReaderCloser. Commonly we would use:
 //
 // 	defer closer.Close()
 //
@@ -14,12 +15,12 @@ package logerrcapture
 //
 // 	func <...>(...) (err error) {
 //  	...
-//  	defer logerrcapture.Close(logger, closer, "log format message")
+//  	defer logerrcapture.Do(logger, closer.Close, "log format message")
 //
 // 		...
 // 	}
 //
-// If closer returns error, `logerrcapture.Close` will capture it, add to input error if not nil and return by argument.
+// If Close returns error, `logerrcapture.Do` will capture it, add to input error if not nil and return by argument.
 //
 // The logerrcapture.ExhaustClose function provide the same functionality but takes an io.ReadCloser and exhausts the whole
 // reader before closing. This is useful when trying to use http keep-alive connections because for the same connection


### PR DESCRIPTION
Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

cc @kakkoyun @GiedriusS does it make sense?