### PR TITLE
Add option to hide PathOrContent flags

### DIFF
--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -51,9 +51,8 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, opts ..
 	}
 
 	if p.hidden {
-		p.path = fileFlag.Hidden().String()
-		p.content = contentFlag.Hidden().String()
-		return p
+		fileFlag = fileFlag.Hidden()
+		contentFlag = contentFlag.Hidden()
 	}
 
 	p.path = fileFlag.String()


### PR DESCRIPTION
This PR refactors `RegisterPathOrContent` and adds `WithHidden` method to allow hiding such flags.