### PR TITLE
Allow identification of type of PathOrContent

### DIFF
--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -96,7 +96,7 @@ func (p *PathOrContent) Content() ([]byte, error) {
 	return content, nil
 }
 
-// Path returns the file path is it's defined. Otherwise returns an empty string.
+// Path returns the file's path.
 func (p *PathOrContent) Path() string {
 	return *p.path
 }

--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -100,17 +100,11 @@ func (p *PathOrContent) Content() ([]byte, error) {
 
 // Path returns the file path is it's defined. Otherwise returns an empty string.
 func (p *PathOrContent) Path() string {
-	if p.path != nil {
-		return *p.path
-	}
-	return ""
+	return *p.path
 }
 
 func (p *PathOrContent) internalContent() string {
-	if p.content != nil {
-		return *p.content
-	}
-	return ""
+	return *p.content
 }
 
 // WithRequired allows you to override default required option.

--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -68,19 +68,21 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, opts ..
 func (p *PathOrContent) Content() ([]byte, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 
-	if len(*p.path) > 0 && len(*p.content) > 0 {
+	path := p.Path()
+	internalContent := p.internalContent()
+	if path != "" && internalContent != "" {
 		return nil, errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
 	}
 
 	var content []byte
-	if len(*p.path) > 0 {
+	if path != "" {
 		c, err := ioutil.ReadFile(*p.path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "loading file %s for %s", *p.path, fileFlagName)
 		}
 		content = c
 	} else {
-		content = []byte(*p.content)
+		content = []byte(internalContent)
 	}
 
 	if len(content) == 0 && p.required {
@@ -94,6 +96,21 @@ func (p *PathOrContent) Content() ([]byte, error) {
 		content = replace
 	}
 	return content, nil
+}
+
+// Path returns the file path is it's defined. Otherwise returns an empty string.
+func (p *PathOrContent) Path() string {
+	if p.path != nil {
+		return *p.path
+	}
+	return ""
+}
+
+func (p *PathOrContent) internalContent() string {
+	if p.content != nil {
+		return *p.content
+	}
+	return ""
 }
 
 // WithRequired allows you to override default required option.

--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -68,21 +68,19 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, opts ..
 func (p *PathOrContent) Content() ([]byte, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 
-	path := p.Path()
-	internalContent := p.internalContent()
-	if path != "" && internalContent != "" {
+	if len(*p.path) > 0 && len(*p.content) > 0 {
 		return nil, errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
 	}
 
 	var content []byte
-	if path != "" {
+	if *p.path != "" {
 		c, err := ioutil.ReadFile(*p.path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "loading file %s for %s", *p.path, fileFlagName)
 		}
 		content = c
 	} else {
-		content = []byte(internalContent)
+		content = []byte(*p.content)
 	}
 
 	if len(content) == 0 && p.required {
@@ -101,10 +99,6 @@ func (p *PathOrContent) Content() ([]byte, error) {
 // Path returns the file path is it's defined. Otherwise returns an empty string.
 func (p *PathOrContent) Path() string {
 	return *p.path
-}
-
-func (p *PathOrContent) internalContent() string {
-	return *p.content
 }
 
 // WithRequired allows you to override default required option.

--- a/extkingpin/pathorcontent.go
+++ b/extkingpin/pathorcontent.go
@@ -73,7 +73,7 @@ func (p *PathOrContent) Content() ([]byte, error) {
 	}
 
 	var content []byte
-	if *p.path != "" {
+	if len(*p.path) > 0 {
 		c, err := ioutil.ReadFile(*p.path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "loading file %s for %s", *p.path, fileFlagName)


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

I wanted to integrate `extkingpin.PathOrContent` with https://github.com/fsnotify/fsnotify to reload configuration when a path is used and the indicated file changes, but it's not achievable without this. 